### PR TITLE
Be a bit less zealous when the mysql connection fails

### DIFF
--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -30,9 +30,9 @@ module.exports = {
 
       connect: function(next){
         api.sequelize.sequelize = new Sequelize(
-          api.config.sequelize.database, 
-          api.config.sequelize.username, 
-          api.config.sequelize.password, 
+          api.config.sequelize.database,
+          api.config.sequelize.username,
+          api.config.sequelize.password,
           api.config.sequelize
         );
 
@@ -42,8 +42,8 @@ module.exports = {
           var name = nameParts[(nameParts.length - 1)].split(".")[0];
           api.models[name] = api.sequelize.sequelize.import(dir + '/' + file);
         });
-        
-        if(api.env === "test"){  
+
+        if(api.env === "test"){
           var SequelizeFixtures = require('sequelize-fixtures');
           SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.json', api.models, function(){
             SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.yml', api.models, function(){
@@ -55,13 +55,28 @@ module.exports = {
         }
       },
 
-      test: function(next){
+      // api.sequelize.test([exitOnError=true], next);
+      // Checks to see if mysql can be reached by selecting the current time
+      // Arguments:
+      //  - exitOnError (optional, default=true): If true, and mysql cannot be reached, actionhero will quit
+      //  - next (callback function()): Will be called after the test, unless exitOnError is true and mysql cannot be reached
+      //      in this case, actionhero will quit and the callback will not be called.
+      test: function(exitOnError, next){
+        if(typeof exitOnError == "function") {
+          next = exitOnError;
+          exitOnError = true;
+        }
+
         api.sequelize.sequelize.query("SELECT NOW()").then(function(){
           next();
         }).catch(function(err){
           api.log(err, 'warning');
           console.log(err);
-          process.exit();
+          if(exitOnError) {
+            process.exit();
+          } else {
+            next();
+          }
         });
       },
 

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -58,25 +58,15 @@ module.exports = {
       // api.sequelize.test([exitOnError=true], next);
       // Checks to see if mysql can be reached by selecting the current time
       // Arguments:
-      //  - exitOnError (optional, default=true): If true, and mysql cannot be reached, actionhero will quit
-      //  - next (callback function()): Will be called after the test, unless exitOnError is true and mysql cannot be reached
-      //      in this case, actionhero will quit and the callback will not be called.
-      test: function(exitOnError, next){
-        if(typeof exitOnError == "function") {
-          next = exitOnError;
-          exitOnError = true;
-        }
-
+      //  - next (callback function(err)): Will be called after the test is complete
+      //      If the test fails, the `err` argument will contain the error
+      test: function(next){
         api.sequelize.sequelize.query("SELECT NOW()").then(function(){
           next();
         }).catch(function(err){
           api.log(err, 'warning');
           console.log(err);
-          if(exitOnError) {
-            process.exit();
-          } else {
-            next();
-          }
+          next(err);
         });
       },
 
@@ -87,8 +77,8 @@ module.exports = {
 
   startPriority: 1001, // the lowest post-core middleware priority
   start: function(api, next){
-    api.sequelize.connect(function(){
-      next();
+    api.sequelize.connect(function(err){
+      next(err);
     });
   }
 };


### PR DESCRIPTION
This is a backwards-compatible change to allow users to status check the connection to the db without `process.exit()`ing the server. My plan is to add a mysql check to the status endpoint, and ideally my server won't have to reboot if the status check fails.