### PR TITLE
add option in .sequelizerc to point at sequelize config.

### DIFF
--- a/config/.sequelizerc
+++ b/config/.sequelizerc
@@ -1,0 +1,5 @@
+// only used for sequelize CLI
+
+module.exports = {
+"config": "./config/sequelize.js"
+};

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -4,15 +4,25 @@ var fs     = require('fs');
 var path   = require('path');
 var mkdirp = require('mkdirp');
 
-var localFile   = path.normalize(__dirname + '/../config/sequelize.js');
-var projectFile = path.normalize(process.cwd() + '/../../config/sequelize.js');
+var localConfigFile   = path.normalize(__dirname + '/../config/sequelize.js');
+var projectConfigFile = path.normalize(process.cwd() + '/../../config/sequelize.js');
+
+var localRcFile   = path.normalize(__dirname + '/../config/.sequelizerc');
+var projectRcFile = path.normalize(process.cwd() + '/../../.sequelizerc');
 
 try {
-  fs.lstatSync(projectFile);
+  fs.lstatSync(projectConfigFile);
 } catch (ex) {
   //unable to stat file because it doesn't exist
-  console.log("coppying " + localFile + " to " + projectFile)
-  fs.createReadStream(localFile).pipe(fs.createWriteStream(projectFile));
+  console.log("copying " + localConfigFile + " to " + projectConfigFile);
+  fs.createReadStream(localConfigFile).pipe(fs.createWriteStream(projectConfigFile));
+}
+
+try {
+  fs.lstatSync(projectRcFile);
+} catch (ex) {
+  console.log("copying " + localRcFile + " to " + projectRcFile + " for ");
+  fs.createReadStream(localRcFile).pipe(fs.createWriteStream(projectRcFile));
 }
 
 ['models', 'test/fixtures'].forEach(function(f){


### PR DESCRIPTION
**sequelize-cli** by default, looks for sequelize config at `config/config.json`. This PR declares the correct location of the config in `.sequelizerc`.