### PR TITLE
Automatically migrate database on start, with config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ grunt.registerTask('migrate:undo','revert and run the “down” action on the l
 
 If you want to sync, you can `api.sequelize.sync()` or `api.models.yourModel.sync()`;
 
+By default, `ah-sequelize-plugin` will automatically execute any pending migrations when Actionhero starts up. You can disable this behaviour by adding `autoMigrate: false` to your sequelize config.
+
 ## [Associations](http://docs.sequelizejs.com/en/latest/api/associations)
 
 If you want to declare associations, best practice has you create an `associations.js` initializer within your project which might look like this:

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -33,6 +33,7 @@ function merge(overlayFn) {
 // exports.production = {
 //   sequelize: function(api){
 //     return {
+//       "autoMigrate" : false,
 //       "logging"     : false,
 //       "database"    : "PRODUCTION_DB",
 //       "dialect"     : "mysql",

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -1,6 +1,7 @@
 exports.default = {
     sequelize: function(api){
         return {
+            "autoMigrate" : true,
             "database"    : "DEVELOPMENT_DB",
             "dialect"     : "mysql",
             "port"        : 3306,

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -78,7 +78,15 @@ module.exports = {
   startPriority: 1001, // the lowest post-core middleware priority
   start: function(api, next){
     api.sequelize.connect(function(err){
-      next(err);
+      if(err) {
+        return next(err);
+      }
+
+      if(api.config.sequelize.autoMigrate) {
+        this.migrate({method: 'up'}, next)
+      } else {
+        next(err);
+      }
     });
   }
 };


### PR DESCRIPTION
We currently migrate our production systems by running a script from our local machines. This will allow us to trigger migrations on the server as it starts up.

I set the automatic migration to be the default behavior, configured by a flag, but I'd be open to making the behavior opt-in rather than opt-out.