### PR TITLE
Fix automigrate, and fixtures should be loaded after migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,6 @@ module.exports = {
 
 ## [Fixtures](https://github.com/domasx2/sequelize-fixtures)
 
-We use the `sequelize-fixtures` package to load in JSON-defined fixtures in the test NODE\_ENV.  Store your fixtures in `./test/fixtures/*.json` or `./test/fixtures/*.yml`
+We use the `sequelize-fixtures` package to load in JSON-defined fixtures in the test NODE\_ENV.  Store your fixtures in `./test/fixtures/*.json` or `./test/fixtures/*.yml`.
+
+By default, `ah-sequelize-plugin` will automatically load your fixtures when Actionhero starts up. You can disable this behaviour by adding `loadFixtures: false` to your sequelize config.

--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ module.exports = {
 
 We use the `sequelize-fixtures` package to load in JSON-defined fixtures in the test NODE\_ENV.  Store your fixtures in `./test/fixtures/*.json` or `./test/fixtures/*.yml`.
 
-By default, `ah-sequelize-plugin` will automatically load your fixtures when Actionhero starts up. You can disable this behaviour by adding `loadFixtures: false` to your sequelize config.
+By default, `ah-sequelize-plugin` will **not** automatically load your fixtures when Actionhero starts up. You can enable this behaviour by adding `loadFixtures: true` to your sequelize config.

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -2,7 +2,7 @@ exports.default = {
     sequelize: function(api){
         return {
             "autoMigrate" : true,
-            "loadFixtures": true,
+            "loadFixtures": false,
             "database"    : "DEVELOPMENT_DB",
             "dialect"     : "mysql",
             "port"        : 3306,

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -2,6 +2,7 @@ exports.default = {
     sequelize: function(api){
         return {
             "autoMigrate" : true,
+            "loadFixtures": true,
             "database"    : "DEVELOPMENT_DB",
             "dialect"     : "mysql",
             "port"        : 3306,
@@ -34,6 +35,7 @@ function merge(overlayFn) {
 //   sequelize: function(api){
 //     return {
 //       "autoMigrate" : false,
+//       "loadFixtures": false,
 //       "logging"     : false,
 //       "database"    : "PRODUCTION_DB",
 //       "dialect"     : "mysql",

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -47,7 +47,7 @@ module.exports = {
       },
 
       loadFixtures: function(next) {
-          if(api.env === "test") {
+          if(api.config.sequelize.loadFixtures) {
             var SequelizeFixtures = require('sequelize-fixtures');
             SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function () {
               next();

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -45,10 +45,8 @@ module.exports = {
 
         if(api.env === "test"){
           var SequelizeFixtures = require('sequelize-fixtures');
-          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.json', api.models, function(){
-            SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.yml', api.models, function(){
-              api.sequelize.test(next);
-            });
+          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function(){
+            api.sequelize.test(next);
           });
         }else{
           api.sequelize.test(next);

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -66,8 +66,7 @@ module.exports = {
           console.log(err);
           next(err);
         });
-      },
-
+      }
     };
 
     next();
@@ -81,7 +80,7 @@ module.exports = {
       }
 
       if(api.config.sequelize.autoMigrate) {
-        this.migrate({method: 'up'}, next)
+        api.sequelize.migrate({method: 'up'}, next)
       } else {
         next(err);
       }

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -43,13 +43,27 @@ module.exports = {
           api.models[name] = api.sequelize.sequelize.import(dir + '/' + file);
         });
 
-        if(api.env === "test"){
-          var SequelizeFixtures = require('sequelize-fixtures');
-          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function(){
-            api.sequelize.test(next);
-          });
-        }else{
-          api.sequelize.test(next);
+        api.sequelize.test(next);
+      },
+
+      loadFixtures: function(next) {
+          if(api.env === "test") {
+            var SequelizeFixtures = require('sequelize-fixtures');
+            SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function () {
+              next();
+            });
+          } else {
+            next();
+          }
+      },
+
+      autoMigrate: function(next) {
+        if(api.config.sequelize.autoMigrate) {
+            api.sequelize.migrate({method: 'up'}, function () {
+              next();
+            });
+        } else {
+            next();
         }
       },
 
@@ -79,11 +93,9 @@ module.exports = {
         return next(err);
       }
 
-      if(api.config.sequelize.autoMigrate) {
-        api.sequelize.migrate({method: 'up'}, next)
-      } else {
-        next(err);
-      }
+      api.sequelize.autoMigrate(function() {
+          api.sequelize.loadFixtures(next);
+      });
     });
   }
 };

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -47,7 +47,7 @@ module.exports = {
       },
 
       loadFixtures: function(next) {
-          if(api.config.sequelize.loadFixtures) {
+          if(api.config.sequelize.loadFixtures == null || api.config.sequelize.loadFixtures) {
             var SequelizeFixtures = require('sequelize-fixtures');
             SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function () {
               next();
@@ -58,7 +58,7 @@ module.exports = {
       },
 
       autoMigrate: function(next) {
-        if(api.config.sequelize.autoMigrate) {
+        if(api.config.sequelize.autoMigrate == null || api.config.sequelize.autoMigrate) {
             api.sequelize.migrate({method: 'up'}, function () {
               next();
             });

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -47,7 +47,7 @@ module.exports = {
       },
 
       loadFixtures: function(next) {
-          if(api.config.sequelize.loadFixtures == null || api.config.sequelize.loadFixtures) {
+          if(api.config.sequelize.loadFixtures) {
             var SequelizeFixtures = require('sequelize-fixtures');
             SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function () {
               next();


### PR DESCRIPTION
PR #16 had a typo, which prevented `autoMigrate` from working.
I have also placed fixtures after autoMigrate - needed if starting from an empty DB.
I enabled `.js` fixtures, as it allows for more flexibility in how the fixtures are defined (allows for use of JSON.stringify). This last feature is subjective - do let me know you views on it.