### PR TITLE
Use umzug for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,57 +38,57 @@ An example migration to create a `users` table would look like:
 ```javascript 
 // from ./migrations/20140101000001-create-users.js
 
+var Promise = require('bluebird');
+
 module.exports = {
-  up: function(migration, DataTypes, done) {
-    migration.createTable('users', {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true
-      },
-      name: DataTypes.STRING,
-      email: DataTypes.STRING,
-      phone: DataTypes.STRING,
-      passwordHash: DataTypes.TEXT,
-      passwordSalt: DataTypes.TEXT,
-      createdAt: DataTypes.DATE
-      updatedAt: DataTypes.DATE
-    }).complete(function(){
-
-    migration.addIndex('users', ['email'], {
-      indexName: 'email_index',
-      indicesType: 'UNIQUE'
-    }).complete(function(){
-
-    migration.addIndex('users', ['name'], {
-      indexName: 'name_index',
-      indicesType: 'UNIQUE'
-    }).complete(function(){
-
-    migration.addIndex('users', ['phone'], {
-      indexName: 'phone_index',
-      indicesType: 'UNIQUE'
-    }).complete(function(){
-
-      done();
-
-    });
-    });
-    });
+  up: function(migration, DataTypes) {
+    return Promise.all([
+      migration.createTable('users', {
+        id: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        name: DataTypes.STRING,
+        email: DataTypes.STRING,
+        phone: DataTypes.STRING,
+        passwordHash: DataTypes.TEXT,
+        passwordSalt: DataTypes.TEXT,
+        createdAt: DataTypes.DATE
+        updatedAt: DataTypes.DATE
+      })
+    ]).then(function(){
+      return Promise.all([
+        migration.addIndex('users', ['email'], {
+          indexName: 'email_index',
+          indicesType: 'UNIQUE'
+        }),
+        migration.addIndex('users', ['name'], {
+          indexName: 'name_index',
+          indicesType: 'UNIQUE'
+        }),
+        migration.addIndex('users', ['phone'], {
+          indexName: 'phone_index',
+          indicesType: 'UNIQUE'
+        })
+      ]);
     });
   },
  
-  down: function(migration, DataTypes, done) {
-    migration.dropTable('users').complete(done);
+  down: function(migration, DataTypes) {
+    return Promise.all([
+      migration.dropTable('users')
+    ]);
   }
 }
 ```
 
 You can use the [sequelize-cli](http://docs.sequelizejs.com/en/latest/docs/migrations/) to create and execute migrations. 
-Using the `migrator` class on `api.sequelize` is [deprecated](https://github.com/sequelize/sequelize/issues/3301#issuecomment-77935976), as Sequelize 
-now recommends using [Umzug](https://github.com/sequelize/umzug) to manage database schemas.
 
-If you want to sync, you can `api.sequelize.sync()` or `api.models.yourModel.sync()`;
+`api.sequelize.migrate` and `api.sequelize.migrateUndo` are now based on [Umzug](https://github.com/sequelize/umzug), and are maintained for legacy purposes.
+An Umzug instance is available at `api.sequelize.umzug`, and should be used to perform (and undo) migrations programatically using the [official API](https://github.com/sequelize/umzug#api).
+
+If you want to sync, you can `api.sequelize.sequelize.sync()` or `api.models.yourModel.sync()`;
 
 By default, `ah-sequelize-plugin` will automatically execute any pending migrations when Actionhero starts up. You can disable this behaviour by adding `autoMigrate: false` to your sequelize config.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-### WARNING TO PEOPLE USING `AUTOMIGRATE` in PRODUCTION! - This plugin now uses Umzug's new migration table format! You should use sequelize-cli's `db:migrate:old_schema` to migrate before restarting your AH server!
-
-
 # ah-sequelize-plugin
 
 This plugin will use the sequelize orm to create `api.models` which contain your sequelize models

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### WARNING TO PEOPLE USING `AUTOMIGRATE` in PRODUCTION! - This plugin now uses Umzug's new migration table format! You should use sequelize-cli's `db:migrate:old_schema` to migrate before restarting your AH server!
+
+
 # ah-sequelize-plugin
 
 This plugin will use the sequelize orm to create `api.models` which contain your sequelize models

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -1,10 +1,15 @@
 var path              = require('path');
 var fs                = require('fs');
 var Sequelize         = require('sequelize');
+var Umzug             = require('umzug');
 
 module.exports = {
   initialize: function(api, next){
     api.models = {};
+
+      var umzugCfg = {
+          path: api.projectRoot + '/migrations'
+      };
 
     api.sequelize = {
 
@@ -15,17 +20,11 @@ module.exports = {
         }
         opts = opts === null ? { method: 'up' } : opts;
 
-        var migrator = api.sequelize.sequelize.getMigrator({
-          path: api.projectRoot + '/migrations'
-        });
-
-        migrator.migrate(opts).then(function() {
-          next();
-        });
+          new Umzug(umzugCfg).execute(opts).then(next());
       },
 
       migrateUndo: function(next) {
-        this.migrate({ method: 'down' }, next);
+          new Umzug(umzugCfg).down().then(next());
       },
 
       connect: function(next){
@@ -59,9 +58,7 @@ module.exports = {
 
       autoMigrate: function(next) {
         if(api.config.sequelize.autoMigrate == null || api.config.sequelize.autoMigrate) {
-            api.sequelize.migrate({method: 'up'}, function () {
-              next();
-            });
+            new Umzug(umzugCfg).up().then(next());
         } else {
             next();
         }

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -31,6 +31,8 @@ module.exports = {
 
         sequelize: sequelizeInstance,
 
+        umzug: umzug,
+
       migrate: function(opts, next){
         if(typeof opts === "function"){
           next = opts;

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -75,9 +75,7 @@ module.exports = {
         if(api.config.sequelize.autoMigrate == null || api.config.sequelize.autoMigrate) {
             migrateSequelizeMeta(api, umzug)
                 .then(function() {
-                    return umzug.up().then(function() {
-                        return;
-                    });
+                    return umzug.up();
                 }).then(function () {
                     next();
                 });

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -124,10 +124,14 @@ module.exports = {
 
 function checkMetaOldSchema(api, umzug) {
     // Check if we need to upgrade from the old sequelize migration format
-    return api.sequelize.sequelize.query('SELECT * FROM "SequelizeMeta"').then(function(raw) {
+    return api.sequelize.sequelize.query('SELECT * FROM "SequelizeMeta"', {raw: true}).then(function(raw) {
         var rows = raw[0];
         if (rows.length && rows[0].hasOwnProperty('id')) {
             throw new Error('Old-style meta-migration table detected - please use `sequelize-cli`\'s `db:migrate:old_schema` to migrate.');
         }
+    }).catch(Sequelize.DatabaseError, function (err) {
+        var noTableMsg = 'No SequelizeMeta table found - creating new table';
+        api.log(noTableMsg);
+        console.log(noTableMsg);
     });
 }

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -7,11 +7,29 @@ module.exports = {
   initialize: function(api, next){
     api.models = {};
 
-      var umzugCfg = {
-          path: api.projectRoot + '/migrations'
-      };
+      var sequelizeInstance = new Sequelize(
+          api.config.sequelize.database,
+          api.config.sequelize.username,
+          api.config.sequelize.password,
+          api.config.sequelize
+      );
+
+      var umzug = new Umzug({
+          storage: 'sequelize',
+          storageOptions: {
+              sequelize: sequelizeInstance
+          },
+          migrations: {
+              params: [sequelizeInstance.getQueryInterface(), sequelizeInstance.constructor, function() {
+                  throw new Error('Migration tried to use old style "done" callback. Please upgrade to "umzug" and return a promise instead.');
+              }],
+              path: api.projectRoot + '/migrations'
+          }
+      });
 
     api.sequelize = {
+
+        sequelize: sequelizeInstance,
 
       migrate: function(opts, next){
         if(typeof opts === "function"){
@@ -20,21 +38,14 @@ module.exports = {
         }
         opts = opts === null ? { method: 'up' } : opts;
 
-          new Umzug(umzugCfg).execute(opts).then(next());
+          umzug.execute(opts).then(next());
       },
 
       migrateUndo: function(next) {
-          new Umzug(umzugCfg).down().then(next());
+          umzug.down().then(next());
       },
 
       connect: function(next){
-        api.sequelize.sequelize = new Sequelize(
-          api.config.sequelize.database,
-          api.config.sequelize.username,
-          api.config.sequelize.password,
-          api.config.sequelize
-        );
-
         var dir = path.normalize(api.projectRoot + '/models');
         fs.readdirSync(dir).forEach(function(file){
           var nameParts = file.split("/");
@@ -58,7 +69,14 @@ module.exports = {
 
       autoMigrate: function(next) {
         if(api.config.sequelize.autoMigrate == null || api.config.sequelize.autoMigrate) {
-            new Umzug(umzugCfg).up().then(next());
+            migrateSequelizeMeta(api, umzug)
+                .then(function() {
+                    return umzug.up().then(function() {
+                        return;
+                    });
+                }).then(function () {
+                    next();
+                });
         } else {
             next();
         }
@@ -96,3 +114,62 @@ module.exports = {
     });
   }
 };
+
+function migrateSequelizeMeta(api, umzug) {
+
+    var migration = api.sequelize.sequelize.getQueryInterface();
+
+    // Check if we need to upgrade from the old sequlize migration format
+    return api.sequelize.sequelize.query('SELECT * FROM "SequelizeMeta";', {
+        raw: true
+
+    }).then(function(raw) {
+
+        var rows = raw[0];
+        if (rows.length && rows[0].hasOwnProperty('id')) {
+
+            var migrationFiles = fs.readdirSync(umzug.options.migrations.path),
+                data = rows.map(function(row) {
+                    return migrationFiles.filter(function(f) {
+                        return f.substring(0, row.to.length) === row.to;
+
+                    })[0];
+                });
+
+            // Drop the existing migration data
+            return api.sequelize.sequelize.query('DELETE FROM "SequelizeMeta";', null, {
+                raw: true
+
+                // Update the table format
+            }).then(function() {
+                return [
+                    migration.renameColumn('SequelizeMeta', 'to', 'name'),
+                    migration.removeColumn('SequelizeMeta', 'from'),
+                    migration.removeColumn('SequelizeMeta', 'id')
+                ];
+                // Insert data in the new migration format
+            }).then(function() {
+                var MetaModel = umzug.storage.options.storageOptions.model;
+
+                return data.map(function(migrationName) {
+                    return MetaModel.create({
+                        name: migrationName
+                    });
+                });
+            }).all();
+        } else {
+            // TODO check the table layout in case it's empty
+            return false;
+        }
+    }).then(function(migrated) {
+        if (migrated) {
+            var completeMsg = 'SequelizeMeta migration complete!';
+            api.log(completeMsg);
+            console.log(completeMsg);
+        }
+    }).catch(Sequelize.DatabaseError, function (err) {
+        var noTableMsg = 'No SequelizeMeta table found - skipping meta migration';
+        api.log(noTableMsg);
+        console.log(noTableMsg);
+    });
+}

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -42,7 +42,9 @@ module.exports = {
       },
 
       migrateUndo: function(next) {
-          umzug.down().then(next());
+          umzug.down().then(function() {
+              next();
+          });
       },
 
       connect: function(next){

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "mkdirp": "^0.3.5"
+    "mkdirp": "^0.3.5",
+    "umzug": "^1.6.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
The migrator in sequelize seems to be using events, so migrations break if sequelize is upgraded to >= 2.1.0 ([Changelog](https://github.com/sequelize/sequelize/blob/master/changelog.md#210)).

This PR uses Umzug for migrations, and maintains the old `migrate` and `migrateUndo` methods.

As Umzug changed SequelizeMeta table, this PR also attempts to migrate it to the new format. I'm assuming most people are using it for testing, so if the migrate fails, they would be able to redo the DB from scratch.

I've placed a big fat warning at the top of the Readme in case there are people using it in production - could there be a npm deprecation WARN on the package as well, just in case?