### PR TITLE
Api injection into model schema function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A `./config/sequelize.js` file will be created which will store your database co
 Use the exports form of sequelize models in `./models` with the file name matching that of the model, IE:
 
 ```javascript
-module.exports = function(sequelize, DataTypes) {
+module.exports = function(sequelize, DataTypes, api) {
   return sequelize.define("Project", {
     name: DataTypes.STRING,
     description: DataTypes.TEXT
@@ -28,7 +28,7 @@ module.exports = function(sequelize, DataTypes) {
 }
 ```
 
-Models are loaded into `api.models`, so the example above would be `api.models.Project`.
+Models are loaded into `api.models`, so the example above would be `api.models.Project`. These module.exports allow for a third optional argument "api" which is the ActionHero API object. This can be used to access configs and initializer functions, among other things.
 
 ## [Migrations](http://docs.sequelizejs.com/en/latest/api/migrations)
 

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -26,6 +26,14 @@ module.exports = {
         path: api.projectRoot + '/migrations'
       }
     });
+    
+    function currySchemaFunc(SchemaExportFunc) {
+      if (SchemaExportFunc.length == 3) {
+        return function(a,b) { return SchemaExportFunc(a,b,api) }
+      } else {
+        return SchemaExportFunc;
+      }
+    };
 
     api.sequelize = {
 
@@ -60,7 +68,8 @@ module.exports = {
         fs.readdirSync(dir).forEach(function(file){
           var nameParts = file.split("/");
           var name = nameParts[(nameParts.length - 1)].split(".")[0];
-          api.models[name] = api.sequelize.sequelize.import(dir + '/' + file);
+          var modelFunc = currySchemaFunc(require(dir + '/' + file));
+          api.models[name] = api.sequelize.sequelize.import(capitalizeFirstLetter(name), modelFunc);
         });
 
         api.sequelize.test(next);

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -69,7 +69,7 @@ module.exports = {
           var nameParts = file.split("/");
           var name = nameParts[(nameParts.length - 1)].split(".")[0];
           var modelFunc = currySchemaFunc(require(dir + '/' + file));
-          api.models[name] = api.sequelize.sequelize.import(capitalizeFirstLetter(name), modelFunc);
+          api.models[name] = api.sequelize.sequelize.import(name, modelFunc);
         });
 
         api.sequelize.test(next);
@@ -132,10 +132,6 @@ module.exports = {
     });
   }
 };
-
-function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-}
 
 function checkMetaOldSchema(api, umzug) {
   // Check if we need to upgrade from the old sequelize migration format

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -28,11 +28,7 @@ module.exports = {
     });
     
     function currySchemaFunc(SchemaExportFunc) {
-      if (SchemaExportFunc.length == 3) {
-        return function(a,b) { return SchemaExportFunc(a,b,api) }
-      } else {
-        return SchemaExportFunc;
-      }
+      return function(a,b) { return SchemaExportFunc(a,b,api) }
     };
 
     api.sequelize = {

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -133,6 +133,10 @@ module.exports = {
   }
 };
 
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 function checkMetaOldSchema(api, umzug) {
   // Check if we need to upgrade from the old sequelize migration format
   return api.sequelize.sequelize.query('SELECT * FROM "SequelizeMeta"', {raw: true}).then(function(raw) {


### PR DESCRIPTION
Built a fun hack today - let me know if this is crazy or compelling.

Upon loading model files, if a third argument is detected in the schema function definition, the api object can be "curried" into the model definition export function and made available to the model and instance functions

*example*
module.exports = function(sequelize, DataTypes, api) {
  // the third argument passes in the fully-loaded ActionHero API Object
 var User = sequelize.define('User', attributes, { ...
   // use the API object inside the getter, setter, class, and instance methods. grow your model definitions' brains.
 })
})