### PR TITLE
Fix imported models names

### DIFF
--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -5,8 +5,6 @@ var Umzug             = require('umzug');
 
 module.exports = {
   initialize: function(api, next){
-    api.models = {};
-
     var sequelizeInstance = new Sequelize(
       api.config.sequelize.database,
       api.config.sequelize.username,
@@ -65,9 +63,10 @@ module.exports = {
           var nameParts = file.split("/");
           var name = nameParts[(nameParts.length - 1)].split(".")[0];
           var modelFunc = currySchemaFunc(require(dir + '/' + file));
-          api.models[name] = api.sequelize.sequelize.import(name, modelFunc);
+          api.sequelize.sequelize.import(name, modelFunc);
         });
 
+        api.models = api.sequelize.sequelize.models;
         api.sequelize.test(next);
       },
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "ah-sequelize-plugin",
   "description": "I use sequelize in actionhero as an ORM",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "homepage": "http://actionherojs.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think use filename as key in `models` - bad idea, file not always have the same name as model. Sequelize knows all about model names, so let him decide.
