### PR TITLE
Reduces log output when using fixtures

### DIFF
--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -83,7 +83,8 @@ module.exports = {
       loadFixtures: function(next) {
         if (api.config.sequelize.loadFixtures) {
           var SequelizeFixtures = require('sequelize-fixtures');
-          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models).then(function() {
+          var options = { log: (api.config.logging)? console.log() : function(){}};
+          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, options).then(function() {
             next();
           });
         } else {

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -83,7 +83,7 @@ module.exports = {
       loadFixtures: function(next) {
         if (api.config.sequelize.loadFixtures) {
           var SequelizeFixtures = require('sequelize-fixtures');
-          var options = { log: (api.config.logging)? console.log() : function(){}};
+          var options = { log: (api.config.logging)? console.log : function(){}};
           SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, options).then(function() {
             next();
           });

--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -83,7 +83,7 @@ module.exports = {
       loadFixtures: function(next) {
         if (api.config.sequelize.loadFixtures) {
           var SequelizeFixtures = require('sequelize-fixtures');
-          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, function() {
+          SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models).then(function() {
             next();
           });
         } else {


### PR DESCRIPTION
PR reduces the logging displayed during testing to make tests more readable, while retaining all logging capabilities when required.

Removes warning generated by `sequelize-fixtures` regarding promises by using promise, rather than callback.

Adds `console.log` override when logging is turned off in the configuration options.